### PR TITLE
Bump Cattle and Go

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,10 @@
-FROM golang:1.7.3
+FROM golang:1.8.0-stretch
 RUN go get github.com/rancher/trash
 RUN go get github.com/golang/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends default-jre python-pip zip xz-utils rsync
+    apt-get install -y --no-install-recommends default-jre python-pip python-setuptools zip xz-utils rsync
 RUN pip install --upgrade pip==6.0.3 tox==1.8.1 virtualenv==12.0.4
 ENV PATH /go/bin:$PATH
 ENV DAPPER_SOURCE /go/src/github.com/rancher/rancher-compose-executor

--- a/scripts/run-cattle
+++ b/scripts/run-cattle
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-URL=https://github.com/rancher/cattle/releases/download/v0.175.10/cattle.jar
+URL=https://github.com/rancher/cattle/releases/download/v0.177.8/cattle.jar
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
Switch to Debian Stretch as base for JRE 8. Stretch was added in Go 1.8 images, so bump Go as well.