### PR TITLE
Add the ability to skip templating

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -2,12 +2,19 @@ package template
 
 import (
 	"bytes"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
 )
 
 func Apply(contents []byte, variables map[string]string) ([]byte, error) {
+	// Skip templating if contents begin with '# notemplating'
+	trimmedContents := strings.TrimSpace(string(contents))
+	if strings.HasPrefix(trimmedContents, "#notemplating") || strings.HasPrefix(trimmedContents, "# notemplating") {
+		return contents, nil
+	}
+
 	t, err := template.New("template").Funcs(sprig.TxtFuncMap()).Parse(string(contents))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds the ability to skip templating by using a `# notemplating` prefix. Useful for rancher/rancher#8271.

rancher/rancher#8051