### PR TITLE
wait for healthcheck to pass before proceeding in stack deploy

### DIFF
--- a/rancher/service.go
+++ b/rancher/service.go
@@ -148,8 +148,8 @@ func (r *RancherService) up(create bool) error {
 	}
 
 	// TODO: revisit whether this is the best place to perform this check
-	if _, ok := r.serviceConfig.Labels["io.rancher.wait_for_healthcheck"]; ok {
-		logrus.Debugf("Detected label io.rancher.wait_for_healthcheck. Polling for health")
+	if _, ok := r.serviceConfig.Labels["io.rancher.service.wait_for_healthcheck"]; ok {
+		logrus.Debugf("Detected label io.rancher.service.wait_for_healthcheck. Polling for health")
 		for {
 			logrus.Debugf("Service %s has health state %s", service.Name, service.HealthState)
 			if service.HealthState == "healthy" {

--- a/rancher/service.go
+++ b/rancher/service.go
@@ -146,19 +146,19 @@ func (r *RancherService) up(create bool) error {
 		service, err = r.context.Client.Service.ActionActivate(service)
 		err = r.Wait(service)
 	}
-	for k, v := range r.serviceConfig.Labels {
-		if k == "wait_for_healthcheck" && v == "true" {
-			logrus.Debugf("Detected label wait_for_healthcheck set to true. Polling for health")
-			for {
-				logrus.Debugf("Service %s has health state %s", service.Name, service.HealthState)
-				if service.HealthState == "healthy" {
-					break
-				}
-				time.Sleep(150 * time.Millisecond)
-				err := r.context.Client.Reload(&service.Resource, service)
-				if err != nil {
-					return err
-				}
+
+	// TODO: revisit whether this is the best place to perform this check
+	if _, ok := r.serviceConfig.Labels["io.rancher.wait_for_healthcheck"]; ok {
+		logrus.Debugf("Detected label io.rancher.wait_for_healthcheck. Polling for health")
+		for {
+			logrus.Debugf("Service %s has health state %s", service.Name, service.HealthState)
+			if service.HealthState == "healthy" {
+				break
+			}
+			time.Sleep(150 * time.Millisecond)
+			err := r.context.Client.Reload(&service.Resource, service)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
thanks for the help figuring this out @joshwget. 

this patch provides the ability for `rancher-compose` to wait for a service to be in state `healthy` before proceeding to the next stack in the dependency chain (based on the use of `depends_on` key). Is only activated when a service has the label `wait_for_healthcheck` set to `true`. 