### PR TITLE
Add ability to create infrastructure stacks

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -63,6 +63,7 @@ func (p *RancherProjectFactory) Create(c *cli.Context) (*project.Project, error)
 	context.Interval = int64(c.Int("interval"))
 	context.ConfirmUpgrade = c.Bool("confirm-upgrade")
 	context.Pull = c.Bool("pull")
+	context.InfrastructureStack = c.Bool("infra")
 
 	return rancher.NewProject(context)
 }
@@ -119,6 +120,10 @@ func UpCommand(factory ProjectFactory) cli.Command {
 			cli.BoolFlag{
 				Name:  "pull, p",
 				Usage: "Before doing the upgrade do an image pull on all hosts that have the image already",
+			},
+			cli.BoolFlag{
+				Name:  "infra, i",
+				Usage: "Create an infrastructure stack rather than a user stack",
 			},
 			cli.BoolFlag{
 				Name:  "d",

--- a/main.go
+++ b/main.go
@@ -81,10 +81,6 @@ func cliMain() {
 			Name:  "env-file,e",
 			Usage: "Specify a file from which to read environment variables",
 		},
-		cli.StringFlag{
-			Name:  "bindings-file,b",
-			Usage: "Specify a file from which to read bindings",
-		},
 	}
 	app.Commands = []cli.Command{
 		rancherApp.CreateCommand(factory),

--- a/rancher/context.go
+++ b/rancher/context.go
@@ -16,17 +16,18 @@ var projectRegexp = regexp.MustCompile("[^a-zA-Z0-9-]")
 type Context struct {
 	project.Context
 
-	Url          string
-	AccessKey    string
-	SecretKey    string
-	Client       *client.RancherClient
-	Stack        *client.Stack
-	isOpen       bool
-	SidekickInfo *SidekickInfo
-	Uploader     Uploader
-	PullCached   bool
-	Pull         bool
-	Args         []string
+	Url                 string
+	AccessKey           string
+	SecretKey           string
+	Client              *client.RancherClient
+	Stack               *client.Stack
+	InfrastructureStack bool
+	isOpen              bool
+	SidekickInfo        *SidekickInfo
+	Uploader            Uploader
+	PullCached          bool
+	Pull                bool
+	Args                []string
 
 	Upgrade        bool
 	ForceUpgrade   bool
@@ -137,9 +138,15 @@ func (c *Context) LoadStack() (*client.Stack, error) {
 		}
 	}
 
-	logrus.Infof("Creating stack %s", projectName)
+	if c.InfrastructureStack {
+		logrus.Infof("Creating infrastructure stack %s", projectName)
+	} else {
+		logrus.Infof("Creating stack %s", projectName)
+	}
+
 	stack, err := c.Client.Stack.Create(&client.Stack{
-		Name: projectName,
+		Name:   projectName,
+		System: c.InfrastructureStack,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Interested in this feature primarily for development. Being able to launch custom versions of infrastructure services such as Kubernetes via the Rancher CLI would be a lot faster than going through catalog.