### PR TITLE
allowing scerets to pass validation

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -132,6 +132,7 @@ var dockerConfigHints = map[string]string{
 	"priviliged":  "privileged",
 	"privilige":   "privileged",
 	"volume":      "volumes",
+	"secret":      "secrets",
 	"workdir":     "working_dir",
 }
 


### PR DESCRIPTION
I am allowing secrets to be part of the yaml so the secrets could be used when deploying sercices using rancher-compose