### PR TITLE
Add splitPreserveQuotes function to templating

### DIFF
--- a/template/funcs/split_preserve_quotes.go
+++ b/template/funcs/split_preserve_quotes.go
@@ -1,0 +1,35 @@
+package funcs
+
+import (
+	"bytes"
+	"unicode"
+)
+
+func SplitPreserveQuotes(s string) []string {
+	var pieces []string
+	var buffer bytes.Buffer
+	inQuotes := false
+
+	for i, r := range s {
+		if unicode.In(r, unicode.Quotation_Mark) {
+			if inQuotes {
+				inQuotes = false
+			} else {
+				inQuotes = true
+			}
+		}
+
+		lastCharacter := i == len(s)-1
+		if (unicode.IsSpace(r) && !inQuotes) || lastCharacter {
+			if lastCharacter {
+				buffer.WriteRune(r)
+			}
+			pieces = append(pieces, buffer.String())
+			buffer = bytes.Buffer{}
+		} else {
+			buffer.WriteRune(r)
+		}
+	}
+
+	return pieces
+}

--- a/template/funcs/split_preserve_quotes_test.go
+++ b/template/funcs/split_preserve_quotes_test.go
@@ -1,0 +1,27 @@
+package funcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitPreserveQuotes(t *testing.T) {
+	assert.Equal(t, []string{
+		"--a",
+	}, SplitPreserveQuotes("--a"))
+	assert.Equal(t, []string{
+		"--a",
+		"--b",
+	}, SplitPreserveQuotes("--a --b"))
+	assert.Equal(t, []string{
+		"--a",
+		"--b='c d'",
+		"--e='f'",
+	}, SplitPreserveQuotes("--a --b='c d' --e='f'"))
+	assert.Equal(t, []string{
+		"--a",
+		"--b=\"c d\"",
+		"--e=\"f\"",
+	}, SplitPreserveQuotes("--a --b=\"c d\" --e=\"f\""))
+}

--- a/template/template.go
+++ b/template/template.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+	"github.com/rancher/rancher-compose-executor/template/funcs"
 )
 
 type ReleaseInfo struct {
@@ -20,7 +21,10 @@ func Apply(contents []byte, releaseInfo ReleaseInfo, variables map[string]string
 		return contents, nil
 	}
 
-	t, err := template.New("template").Funcs(sprig.TxtFuncMap()).Parse(string(contents))
+	templateFuncs := sprig.TxtFuncMap()
+	templateFuncs["splitPreserveQuotes"] = funcs.SplitPreserveQuotes
+
+	t, err := template.New("template").Funcs(templateFuncs).Parse(string(contents))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
General use case is for converting a single string to a command-like list in a Compose file.

```
--a --b='c d'
```
->
```
- --a
- --b='c d'
```