### PR TITLE
FIX: checking that defaultcert is not <nil>

### DIFF
--- a/rancher/certs.go
+++ b/rancher/certs.go
@@ -7,7 +7,7 @@ import (
 )
 
 func populateCerts(apiClient *client.RancherClient, lbService *CompositeService, defaultCert string, certs []string) error {
-	if defaultCert != "" {
+	if defaultCert != "<nil>" && defaultCert != "" {
 		certId, err := findCertByName(apiClient, defaultCert)
 		if err != nil {
 			return err


### PR DESCRIPTION
If you want to use optional certificate type value in you rancher-compose, to make packages that optionally could be connected plain or encrypted...

```
......
    - variable: "PUBLISH_SCHEMA"
      description: "Publish schema" 
      label: "Publish schema:"
      required: true
      default: "https"
      type: "enum"
      options:
        - http
        - https
    - variable: "SSL_CERT"
      description: "Select SSL certificate." 
      label: "SSL certificate:"
      required: false
      type: "certificate"
services:
  lb:
    scale: 1
    lb_config:
      certs: []
      default_cert: ${SSL_CERT}
      port_rules:
      - protocol: ${PUBLISH_SCHEMA}
        service: <SERVICE>
        source_port: <PORT>
        target_port: <PORT>
    health_check:
      response_timeout: 2000
      healthy_threshold: 2
      port: 42
      unhealthy_threshold: 3
```

If $SSL_CERT is not set, it pass the string ```"<nil>"``` to default_cert, making that deployment fails. This PR is indeed to solve it. 