### PR TITLE
Make Kubernetes resource names unique

### DIFF
--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -74,7 +74,7 @@ func Apply(kubeconfigLocation, name, namespace string, resource interface{}) err
 	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigLocation, "-n", namespace, "apply", "-f", "-")
 	cmd.Stdin = bytes.NewReader(resourceBytes)
 
-	log.Infof("Creating Kubernetes resource %s", name)
+	log.Infof("Applying Kubernetes resource %s", name)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("Failed to apply Kubernetes resource %s: %v (%s)", name, err, output)
 	}

--- a/parser/kubernetes/kubernetes.go
+++ b/parser/kubernetes/kubernetes.go
@@ -1,10 +1,12 @@
 package kubernetes
 
 import (
+	"fmt"
 	"gopkg.in/yaml.v2"
 )
 
 type kubernetesResource struct {
+	Kind             string             `yaml:"kind,omitempty"`
 	Metadata         kubernetesMetadata `yaml:"metadata,omitempty"`
 	ResourceContents map[string]interface{}
 }
@@ -18,11 +20,11 @@ func GetResource(contents []byte) (string, map[string]interface{}, error) {
 	if err := yaml.Unmarshal(contents, &resource); err != nil {
 		return "", nil, err
 	}
-	if resource.Metadata.Name == "" {
+	if resource.Kind == "" || resource.Metadata.Name == "" {
 		return "", nil, nil
 	}
 	if err := yaml.Unmarshal(contents, &resource.ResourceContents); err != nil {
 		return "", nil, err
 	}
-	return resource.Metadata.Name, resource.ResourceContents, nil
+	return fmt.Sprintf("%s/%s", resource.Kind, resource.Metadata.Name), resource.ResourceContents, nil
 }


### PR DESCRIPTION
Different Kubernetes resource kinds can have the same name, so it doesn't make sense to store these based on `metadata.name` alone. They're now named with `<kind>/<metadata.name>`.