### PR TITLE
convert mode to string and always assume octal number

### DIFF
--- a/rancher/configs.go
+++ b/rancher/configs.go
@@ -2,7 +2,6 @@ package rancher
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -203,7 +202,7 @@ func setupSecrets(r *RancherService, name string, result *client.LaunchConfig, s
 			Name:     secret.Target,
 			Uid:      secret.Uid,
 			Gid:      secret.Gid,
-			Mode:     strconv.Itoa(int(secret.Mode)),
+			Mode:     string(secret.Mode),
 		})
 	}
 	return nil

--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -37,30 +37,28 @@ func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // StringorOctalInt reprents a string or an integer or an octal integer
-type StringorOctalInt int64
+type StringorOctalInt string
 
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *StringorOctalInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var intType int64
 	if err := unmarshal(&intType); err == nil {
 		if intType <= 0777 {
-			intType, err = strconv.ParseInt(strconv.FormatInt(intType, 8), 10, 64)
-			if err != nil {
-				return err
-			}
+			*s = StringorOctalInt(strconv.FormatInt(intType, 8))
+		} else {
+			*s = StringorOctalInt(strconv.FormatInt(intType, 10))
 		}
 
-		*s = StringorOctalInt(intType)
 		return nil
 	}
 
 	var stringType string
 	if err := unmarshal(&stringType); err == nil {
-		intType, err := strconv.ParseInt(stringType, 10, 64)
+		intValue, err := strconv.ParseInt(stringType, 8, 64)
 		if err != nil {
 			return err
 		}
-		*s = StringorOctalInt(intType)
+		*s = StringorOctalInt(strconv.FormatInt(intValue, 8))
 		return nil
 	}
 

--- a/yaml/types_yaml_test.go
+++ b/yaml/types_yaml_test.go
@@ -55,11 +55,22 @@ type StructStringorOctalInteger struct {
 }
 
 func TestStringorOctalIntYAML(t *testing.T) {
-	for _, str := range []string{`{mode: 0777}`, `{mode: "0777"}`} {
+	testCases := map[string]string{
+		`{mode: 1777}`:   "1777",
+		`{mode: 0777}`:   "777",
+		`{mode: "777"}`:  "777",
+		`{mode: "0777"}`: "777",
+		`{mode: "1777"}`: "1777",
+	}
+	failTestCases := map[string]string{
+		`{mode: "292"}`:  "",
+		`{mode: "0292"}`: "",
+	}
+	for test, expected := range testCases {
 		s := StructStringorOctalInteger{}
-		yaml.Unmarshal([]byte(str), &s)
+		yaml.Unmarshal([]byte(test), &s)
 
-		assert.Equal(t, StringorOctalInt(777), s.Mode)
+		assert.Equal(t, StringorOctalInt(expected), s.Mode)
 
 		d, err := yaml.Marshal(&s)
 		assert.Nil(t, err)
@@ -67,6 +78,12 @@ func TestStringorOctalIntYAML(t *testing.T) {
 		s2 := StructStringorOctalInteger{}
 		yaml.Unmarshal(d, &s2)
 
-		assert.Equal(t, StringorOctalInt(777), s.Mode)
+		assert.Equal(t, StringorOctalInt(expected), s.Mode)
+	}
+
+	for test := range failTestCases {
+		s := StructStringorOctalInteger{}
+		err := yaml.Unmarshal([]byte(test), &s)
+		assert.NotNil(t, err)
 	}
 }


### PR DESCRIPTION
supported cases:
0777   ====> "777"
1777   ====> "1777"
"777"  ====> "777"
"0777" ====> "777"
"1777" ====> "1777"

will throw validation error:
"292"  ====> invalid
"0292" ====> invalid