### PR TITLE
don't swallow the error

### DIFF
--- a/executor/handlers/project.go
+++ b/executor/handlers/project.go
@@ -21,6 +21,9 @@ func constructProject(stack *client.Stack, cluster *client.Cluster, opts client.
 	// TODO: don't create each time
 	opts.Url = fmt.Sprintf("%s/projects/%s/schemas", opts.Url, stack.AccountId)
 	rancherClient, err := client.NewRancherClient(&opts)
+	if err != nil {
+		return nil, err
+	}
 
 	templateVersion, err := loadTemplateVersion(stack, rancherClient)
 	if err != nil {


### PR DESCRIPTION
@ibuildthecloud fixed your bug :)
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ed8c3e]

goroutine 70 [running]:
github.com/rancher/rancher-compose-executor/executor/handlers.loadTemplateVersion(0xc420934000, 0x0, 0x2ba3c00, 0xc4200181e0, 0x2)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/project.go:56 +0x5e
github.com/rancher/rancher-compose-executor/executor/handlers.constructProject(0xc420934000, 0xc4206229c0, 0xc420193c60, 0x18, 0xc4200160a2, 0x14, 0xc42001a112, 0x28, 0x6fc23ac00, 0x1b, ...)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/project.go:25 +0x1dc
github.com/rancher/rancher-compose-executor/executor/handlers.createStackProject(0xc420926270, 0xc4200fe400, 0xc4209185c0, 0x1b, 0x1fc7640)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/handler.go:106 +0x1b8
github.com/rancher/rancher-compose-executor/executor/handlers.stackDelete(0xc420926270, 0xc4200fe400, 0x0, 0x0)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/handler.go:78 +0x4b
github.com/rancher/rancher-compose-executor/executor/handlers.doAction(0xc420926270, 0xc4200fe400, 0x224099e, 0xc, 0x22b2a28, 0x2098120, 0x0)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/handler.go:42 +0x281
github.com/rancher/rancher-compose-executor/executor/handlers.DeleteStack(0xc420926270, 0xc4200fe400, 0xc420040dd8, 0x1343e01)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/handler.go:31 +0x56
github.com/rancher/rancher-compose-executor/executor/handlers.WithTimeout.func1(0xc420926270, 0xc4200fe400, 0xc4209163c0, 0x2d)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/executor/handlers/common.go:66 +0x51
github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events.doWork(0xc420926270, 0xc4208dc750, 0xc4200fe400, 0x2ba3ac0, 0xc4209126e0)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events/worker.go:94 +0x28d
github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events.(*skippingWorkerPool).HandleWork.func1(0xc4208fa210, 0x2, 0xc420926270, 0xc4208dc750, 0xc4200fe400)
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events/worker.go:47 +0x9e
created by github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events.(*skippingWorkerPool).HandleWork
	/Users/daishanpeng/gprojects/rancher-compose-executor/src/github.com/rancher/rancher-compose-executor/vendor/github.com/rancher/event-subscriber/events/worker.go:48 +0x18d
```